### PR TITLE
Fix link to Get Started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # flux-get-started
 
 We published a step-by-step run-through on how to use Flux and Helm Operator [over
-here](https://github.com/fluxcd/flux/blob/master/docs/install/helm-get-started.md).
+here](https://github.com/fluxcd/flux/blob/master/docs/tutorials/get-started-helm.md).
 
 ### Workloads
 


### PR DESCRIPTION
The current link is broken, this fixes it.