### PR TITLE
Add CircleCI validation job for Kubernetes resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+jobs:
+  validate-yamls:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - run:
+          name: Install kubeval and hrval
+          command: |
+            curl -sL https://raw.githubusercontent.com/stefanprodan/hrval-action/v2.3.0/src/deps.sh | sudo bash
+            sudo curl -sL https://raw.githubusercontent.com/stefanprodan/hrval-action/v2.3.0/src/hrval.sh \
+              -o /usr/local/bin/hrval.sh && sudo chmod +x /usr/local/bin/hrval.sh
+            sudo curl -sL https://raw.githubusercontent.com/stefanprodan/hrval-action/v2.3.0/src/hrval-all.sh \
+              -o /usr/local/bin/hrval && sudo chmod +x /usr/local/bin/hrval
+      - run:
+          name: Validate workloads
+          environment:
+            KUBE_VER: "1.16.0"
+          command: |
+            kubeval --strict --ignore-missing-schemas --kubernetes-version ${KUBE_VER} -d namespaces,workloads,releases
+      - run:
+          name: Validate releases
+          environment:
+            IGNORE_VALUES: "false"
+            KUBE_VER: "1.15.0"
+            HELM_VER: "v2"
+          command: |
+            hrval releases/ $IGNORE_VALUES $KUBE_VER $HELM_VER
+
+workflows:
+  version: 2
+  validate:
+    jobs:
+      - validate-yamls:
+          filters:
+            branches:
+              ignore:
+                - gh-pages

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # flux-get-started
 
+[![CircleCI](https://circleci.com/gh/fluxcd/flux-get-started.svg?style=svg)](https://circleci.com/gh/fluxcd/flux-get-started)
+
 We published a step-by-step run-through on how to use Flux and Helm Operator [over
 here](https://github.com/fluxcd/flux/blob/master/docs/tutorials/get-started-helm.md).
 
-### Workloads
+## Workloads
 
 [podinfo](https://github.com/stefanprodan/podinfo)
 * Kubernetes deployment, ClusterIP service and Horizontal Pod Autoscaler
 * init container automated image updates (regular expression filter)
 * container automated image updates (semantic versioning filter)
 
-### Helm releases
+## Helm Releases
 
 Mongodb
 * Source: Helm repository (stable)
@@ -27,7 +29,13 @@ Ghost
 * disabled automated image updates (glob filter)
 * has external dependency - mariadb (stable)
 
-## <a name="help"></a>Getting Help
+## Manifests Validation
+
+CircleCI [jobs](./.circleci/config.yml):
+* validate Kubernetes manifests with [kubeval](https://github.com/instrumenta/kubeval)
+* validate Flux Helm Releases with [hrval](https://github.com/stefanprodan/hrval-action)
+
+### <a name="help"></a>Getting Help
 
 If you have any questions about, feedback for or problems with `flux-get-started`:
 

--- a/releases/ghost.yaml
+++ b/releases/ghost.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   releaseName: ghost
   chart:
-    git: ssh://git@github.com/weaveworks/flux-get-started
+    git: ssh://git@github.com/fluxcd/flux-get-started
     ref: master
     path: charts/ghost
   values:


### PR DESCRIPTION
This PR adds a CircleCI job for verifying the Kubernetes resources defined in git using schemas generated from the Kubernetes OpenAPI specification:
- validates Kubernetes manifests with [kubeval](https://github.com/instrumenta/kubeval)
- validates Flux Helm Releases with [hrval](https://github.com/stefanprodan/hrval-action)