### PR TITLE
Fix error breaking non-root policy mongodb

### DIFF
--- a/releases/mongodb.yaml
+++ b/releases/mongodb.yaml
@@ -22,5 +22,3 @@ spec:
       enabled: false
     securityContext:
       enabled: true
-      fsGroup: 0
-      runAsUser: 0


### PR DESCRIPTION
Hi,

i've spotted the "Error: container's runAsUser breaks non-root policy" in my events and traced it down to, the securityContext  runAsUser/fsGroup. 

The chart defaults (https://github.com/helm/charts/blob/e1b97b9232d7273127f53c7899d2377d5912f267/stable/mongodb/values-production.yaml#L113) already specify runAsUser and fsGroup 1001 and mongodb starts successfully with this configuration.
A bit strange tho' because there is no UID/GID defined 1001 in the container.