### PR TITLE
Point to new location of stable Helm charts for Ghost requirements

### DIFF
--- a/charts/ghost/requirements.yaml
+++ b/charts/ghost/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   version: 7.x.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   condition: mariadb.enabled
   tags:
     - ghost-database


### PR DESCRIPTION
Related to https://helm.sh/blog/new-location-stable-incubator-charts/